### PR TITLE
Use secrets instead of run cmd for token

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,5 +25,5 @@ async function init(token) {
     stupidAssBot.connect();
 }
 
-const tokenFromStupidCommand = process.argv[2]
-init(tokenFromStupidCommand);
+const tokenFromStupidEnv = process.env.token
+init(tokenFromStupidEnv);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Discord can eat my ass",
   "main": "index.js",
   "scripts": {
-    "run": "npm i && node ."
+    "start": "npm i && node ."
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@
 - Click on secrets
 - Type `token` into the key field
 - Paste your token into the value field
+- Click on `Add new secret`
 - Then on the left side of the replit window click ok (there should be like a field with `npm run start` text in it, the button is below that)
 - Then click on the big green run button in the top middle of the window
 - Invite the bot using the URL put into console

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 - Obtain your token
 - Go to the dock tab in the bottom left of the replit window
 - Click on secrets
-- type `token` into the key field
+- Type `token` into the key field
 - Paste your token into the value field
 - Then on the left side of the replit window click ok (there should be like a field with `npm run start` text in it, the button is below that)
 - Then click on the big green run button in the top middle of the window
@@ -14,9 +14,6 @@
 - Use the `/lol` command
 - If your bot is brand new, you will need to wait up to 24h for your bot to be fully registered as "active"
 - Once you are eligible, get the badge at the [Application site](https://discord.com/developers/active-developer)
-
-### Example
-`npm run run V2h5IGRpZCB5b3UgYWN0dWFsbHkgZGVjb2RlIGl0Pw.GIxRdU._UxMrJsWYKLAROyis_Kkv7XsXk-7Hjvuc7nIXg`
 
 
 ### Extra note

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,12 @@
 - Create an application at the [Developer panel](https://discord.com/developers/applications/) (or you can use a previously existing one)
 - Make it into a bot if it isn't already one
 - Obtain your token
-- Run the command `npm run run BOT_TOKEN_HERE`
+- Go to the dock tab in the bottom left of the replit window
+- Click on secrets
+- type `token` into the key field
+- Paste your token into the value field
+- Then on the left side of the replit window click ok (there should be like a field with `npm run start` text in it, the button is below that)
+- Then click on the big green run button in the top middle of the window
 - Invite the bot using the URL put into console
 - Use the `/lol` command
 - If your bot is brand new, you will need to wait up to 24h for your bot to be fully registered as "active"


### PR DESCRIPTION
When people were to go to a replit page they can see all the files, including the .replit.
And because this bot uses the arguments to get the token people can see the bots token in the .replit file.
This would be bad bcs people can then take over those bots and do bad stuff in theyre servers.

So i made this pr that uses env instead. Altough bcs of ntts made a vid on this that uses the args and not the env, that vid would be outdated so idk if this pr should be merged

I also changed the package.json so you dont have todo `npm run run`. now you can just do `npm start`